### PR TITLE
add configuration to pass the github app private key by value

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -125,9 +125,11 @@ export const readGithubAppPrivateKey = (
   content: string | undefined,
 ): string => {
   if (path !== undefined) {
+    getLogger().info(`read private key file: ${path}`);
     return fs.readFileSync(path, "utf-8");
   }
   if (content !== undefined) {
+    getLogger().info("use private key passed by value");
     return content;
   }
   throw new Error("invalid args. path and content are undefined");

--- a/src/util.ts
+++ b/src/util.ts
@@ -120,6 +120,19 @@ export const configLogger = () => {
   });
 };
 
+export const readGithubAppPrivateKey = (
+  path: string | undefined,
+  content: string | undefined,
+): string => {
+  if (path !== undefined) {
+    return fs.readFileSync(path, "utf-8");
+  }
+  if (content !== undefined) {
+    return content;
+  }
+  throw new Error("invalid args. path and content are undefined");
+};
+
 declare const _loggerCat: unique symbol;
 export type LoggerCat = string & { readonly [_loggerCat]: never };
 


### PR DESCRIPTION
Add a configuration to pass the GitHub App private key directly as a value, without using a file.

In our use case, it is preferable to pass the secret directly to `autoproject` via an environment variable.  
Therefore, we have introduced a new environment variable, `GITHUB_APP_PRIVATE_KEY`.

If the existing `GITHUB_APP_PRIVATE_KEY_FILE` is set, the behavior will remain unchanged.
