### PR TITLE
change renovate option to disable automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
+      "automerge": false
     }
   ],
   "postUpdateOptions": ["yarnDedupeHighest"]


### PR DESCRIPTION
# 概要

npmのサプライチェーンアタックに対応して全てのnpmに依存しているrepositoryのautomergeを停止します