### PR TITLE
add minimumReleaseAge option in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,10 @@
     {
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": false
+    },
+    {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "7 days"
     }
   ],
   "postUpdateOptions": ["yarnDedupeHighest"]


### PR DESCRIPTION
# 概要

npmのサプライチェーンアタックに対応として、npmから7日間新しいpackageの受け入れを遅延させます。